### PR TITLE
remove Dove comment of 2.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > Distribute your Feathers services as microservices
 
-The [`master`](https://github.com/kalisio/feathers-distributed) branch and >= 2.0.x version is expected to work with [Feathers v5](https://dove.docs.feathersjs.com/) (a.k.a. Dove).
+The [`master`](https://github.com/kalisio/feathers-distributed) branch version (`"@kalisio/feathers-distributed": "kalisio/feathers-distributed#master"`) is expected to work with [Feathers v5](https://dove.docs.feathersjs.com/) (a.k.a. Dove).
 
 The [`buzzard`](https://github.com/kalisio/feathers-distributed/tree/buzzard) branch and >= 0.3.x version is expected to work with [Feathers v3](https://buzzard.docs.feathersjs.com/) (a.k.a. Buzzard) and [Feathers v4](https://docs.feathersjs.com/) (a.k.a. Crow) **but will be soon deprecated**.
 


### PR DESCRIPTION
### Summary

Currently none of the 2.0.x versions actually work with dove and koa default adapter. This PR modifies the Readme to remove reference to 2.0.x and instead references using master branch until new version is released. This will avoid confusion about is using standard NPM install guidelines for Dove.

Closes #110
